### PR TITLE
Accessibility: High Contrast theme support and Focus indicator for Chart control

### DIFF
--- a/src/System.Windows.Forms.DataVisualization/ChartWinControl.cs
+++ b/src/System.Windows.Forms.DataVisualization/ChartWinControl.cs
@@ -191,6 +191,9 @@ namespace System.Windows.Forms.DataVisualization.Charting
 			// NOTE: Fixes issue #4475
 			this.SetStyle(ControlStyles.DoubleBuffer, true);
 
+			// This is necessary to raise focus event on chart mouse click.
+			this.SetStyle(ControlStyles.UserMouse, true);
+
 			//*********************************************************
 			//** Create services
 			//*********************************************************
@@ -2075,7 +2078,44 @@ namespace System.Windows.Forms.DataVisualization.Charting
         }
 
 		#endregion
-		
+
+		#region Control protected methods
+
+		protected override void OnGotFocus(EventArgs e)
+		{
+			base.OnGotFocus(e);
+
+			using (Graphics g = Graphics.FromHwndInternal(Handle))
+			{
+				ControlPaint.DrawFocusRectangle(g, new Rectangle(1, 1, Size.Width - 2, Size.Height - 2));
+			}
+		}
+
+		protected override void OnLostFocus(EventArgs e)
+		{
+			base.OnLostFocus(e);
+
+			using (Graphics g = Graphics.FromHwndInternal(Handle))
+			{
+				using (Brush b = new SolidBrush(BackColor))
+				{
+					Rectangle topBorder = new Rectangle(1, 1, Size.Width - 2, 1);
+					g.FillRectangle(b, topBorder);
+
+					Rectangle rightBorder = new Rectangle(Size.Width - 2, 1, 1, Size.Height - 2);
+					g.FillRectangle(b, rightBorder);
+
+					Rectangle bottomBorder = new Rectangle(1, Size.Height - 2, Size.Width - 2, 1);
+					g.FillRectangle(b, bottomBorder);
+
+					Rectangle leftBorder = new Rectangle(1, 1, 1, Size.Height - 2);
+					g.FillRectangle(b, leftBorder);
+				}
+			}
+		}
+
+		#endregion
+
 		#region ISupportInitialize implementation
 
 		/// <summary>

--- a/src/System.Windows.Forms.DataVisualization/DataManager/DataPoint.cs
+++ b/src/System.Windows.Forms.DataVisualization/DataManager/DataPoint.cs
@@ -3990,6 +3990,10 @@ namespace System.Windows.Forms.DataVisualization.Charting
 						{
 							return (Color)series.EmptyPointStyle.GetAttributeObject(CommonCustomProperties.LabelForeColor);
 						}
+						if(SystemInformation.HighContrast)
+						{
+							return Drawing.SystemColors.WindowText;
+						}
 
 						return series.fontColor;
 
@@ -4836,6 +4840,10 @@ namespace System.Windows.Forms.DataVisualization.Charting
 						{
 							return (Color)series.EmptyPointStyle.GetAttributeObject(CommonCustomProperties.LabelBackColor);
 						}
+						if(SystemInformation.HighContrast)
+						{
+							return Drawing.SystemColors.Window;
+						}
 
 						return series.labelBackColor;
 					}
@@ -4885,6 +4893,10 @@ namespace System.Windows.Forms.DataVisualization.Charting
 						if(this.isEmptyPoint)
 						{
 							return (Color)series.EmptyPointStyle.GetAttributeObject(CommonCustomProperties.LabelBorderColor);
+						}
+						if(SystemInformation.HighContrast)
+						{
+							return Drawing.SystemColors.ActiveBorder;
 						}
 
 						return series.labelBorderColor;

--- a/src/System.Windows.Forms.DataVisualization/General/ChartArea.cs
+++ b/src/System.Windows.Forms.DataVisualization/General/ChartArea.cs
@@ -132,6 +132,7 @@ namespace System.Windows.Forms.DataVisualization.Charting
         // Private data members, which store properties values
         private Axis[] _axisArray = new Axis[4];
         private Color _backColor = Color.Empty;
+        private bool _backColorIsSet = false;
         private ChartHatchStyle _backHatchStyle = ChartHatchStyle.None;
         private string _backImage = "";
         private ChartImageWrapMode _backImageWrapMode = ChartImageWrapMode.Tile;
@@ -619,11 +620,19 @@ namespace System.Windows.Forms.DataVisualization.Charting
         {
             get
             {
+                if (SystemInformation.HighContrast && _backColor.IsEmpty && !_backColorIsSet)
+                {
+                    return Drawing.SystemColors.Control;
+                }
+
                 return _backColor;
             }
             set
             {
                 _backColor = value;
+
+                _backColorIsSet = true;
+
                 Invalidate();
             }
         }


### PR DESCRIPTION
Porting accessibility fixes for issues 826994, 827003: support high contrast themes by Chart control labels (if the colors for labels are not specified explicitly), focus indicator for chart control.