### PR TITLE
Use Size from System.Drawing instead of WindowsBase

### DIFF
--- a/src/System.Windows.Forms.DataVisualization/ChartWinControl.cs
+++ b/src/System.Windows.Forms.DataVisualization/ChartWinControl.cs
@@ -28,6 +28,8 @@ using System.Windows.Forms.Design.DataVisualization.Charting;
 
 namespace System.Windows.Forms.DataVisualization.Charting
 {
+    using Size = System.Drawing.Size;
+
     #region Enumerations
 
     /// <summary>

--- a/src/System.Windows.Forms.DataVisualization/Utilities/XmlSerializer.cs
+++ b/src/System.Windows.Forms.DataVisualization/Utilities/XmlSerializer.cs
@@ -50,6 +50,8 @@ using System.Xml;
 
 namespace System.Windows.Forms.DataVisualization.Charting.Utilities
 {
+    using Size = System.Drawing.Size;
+
     #region Serialization enumerations
 
     /// <summary>


### PR DESCRIPTION
Fixes #24

This assembly was provided inbox on Desktop Framework and has been ported to .NET Core in order to support porting of applications making use of it.

The source code lives in `System.Windows.Forms.DataVisualization.Charting` and wants to use `System.Drawing.Size` by importing its namespace via `using System.Drawing`. Due to .NET Core adding an implicit reference to WindowsBase which contains `System.Windows.Size` from WPF (which was not referenced in Desktop Framework) any unqualified source code reference to `Size` may silently prefer the WPF version because it lives in a parent namespace (in contrast to an imported namespace).

References which were leading to conflicts had been resolved in the initial port, but some occurences which did not lead to compile-time conflicts were missed, which leads to both design-time and runtime errors.

## Proposed changes

- Remove all references to the `Size` type from WindowsBase by adding appropriate aliases

## Customer Impact

- Fixes a regression from Desktop Framework:
  - The designer attribute for the chart size was referencing the wrong type.
  - The custom serialization code referenced the wrong `Size` types.

## Regression? 

- Yes, regression in port from Desktop Framework

## Risk

- Low, bug was not present in Desktop Framework, it is unlikely anyone took a dependency on it since there are no known workarounds

## Test methodology

- Inspected the resulting assembly of a local build with `ildasm` to make sure the assembly reference to WindowsBase is gone, indicating the compiler no longer resolves any symbols against WindowsBase

- Code from initial issue report runs without exception
