### PR TITLE
Removing non AzDo feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <!--Removing the non AzDo package sources as they are not allowed anymore.
+    Appropriate feeds need to be added here to get the code to build.-->
   </packageSources>
 </configuration>


### PR DESCRIPTION
Removing the non AzDo feeds as they are not allowed anymore. Appropriate feeds need to be added to get the source code building.