### PR TITLE
Update public pool names

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -1,7 +1,7 @@
 parameters:
   # parameters should default to values for running in the External / Public
   # be read from a user-defined variable (Azure DevOps limitation)
-  agentPoolName: NetCore1ESPool-Public
+  agentPoolName: NetCore-Public
   agentPool: Build.Windows.10.Amd64.VS2019.Pre.Open
   runAsPublic: true                      
   repoName: dotnet/winforms     


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.